### PR TITLE
Include 201 CREATED in HTTP success response codes

### DIFF
--- a/apitools/base/py/base_api.py
+++ b/apitools/base/py/base_api.py
@@ -598,6 +598,7 @@ class BaseApiService(object):
     def __ProcessHttpResponse(self, method_config, http_response, request):
         """Process the given http response."""
         if http_response.status_code not in (http_client.OK,
+                                             http_client.CREATED,                                             
                                              http_client.NO_CONTENT):
             raise exceptions.HttpError.FromResponse(
                 http_response, method_config=method_config, request=request)

--- a/apitools/base/py/base_api.py
+++ b/apitools/base/py/base_api.py
@@ -598,7 +598,7 @@ class BaseApiService(object):
     def __ProcessHttpResponse(self, method_config, http_response, request):
         """Process the given http response."""
         if http_response.status_code not in (http_client.OK,
-                                             http_client.CREATED,                                             
+                                             http_client.CREATED,
                                              http_client.NO_CONTENT):
             raise exceptions.HttpError.FromResponse(
                 http_response, method_config=method_config, request=request)


### PR DESCRIPTION
Previously, we only accepted 200 OK and 204 NO_CONTENT. Some APIs we'd like to use this library with return 201 CREATED when creating a resource, so that should also count as success (and behave like 200 OK).